### PR TITLE
Enable address and integer sanitizers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,13 @@ matrix:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
     - os: linux
-      env: CXX=clang++ BUILDTYPE=Debug MASON_CLANG=true
+      env: CXX=clang++ BUILDTYPE=Debug CXXFLAGS="-fsanitize=address" MASON_CLANG=true
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++6','libstdc++-5-dev' ]
+    - os: linux
+      env: CXX=clang++ BUILDTYPE=Debug CXXFLAGS="-fsanitize=integer" MASON_CLANG=true
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]


### PR DESCRIPTION
Gets the clang 3.8 sanitizers going. One job per sanitizer since they cannot be combined.

These will have minimal value until we have greater test coverage, but going to get them in place now.

- refs #9