### PR TITLE
fixture test error output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ build-fixture-tester:
 
 test: build-test build-fixture-tester
 	./test
+	./tests/run-geometry-tests.sh ./fixture-tester
 
 debug: build-debug build-fixture-tester
 	./test

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ test: build-test build-fixture-tester
 
 debug: build-debug build-fixture-tester
 	./test
+t	./tests/run-geometry-tests.sh ./fixture-tester
 
 clean:
 	rm -f test

--- a/tests/run-geometry-tests.sh
+++ b/tests/run-geometry-tests.sh
@@ -1,12 +1,43 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # ./tests/run-geometry-tests.sh ./fixture-tester
+TESTER="$1"
+PASSES=0
+FAILS=0
+
+if [ -z "$TESTER" ]; then
+    echo "Error: path to a fixture-tester binary must be supplied"
+    exit 1
+elif [ ! -e "$TESTER" ]; then
+    echo "Error: path to fixture-tester binary is invalid"
+    exit 1
+fi
+
+
+mkdir -p ./tests/output-polyjson
 
 for filename in $(ls ./tests/geometry-test-data/input-polyjson)
 do
     for type in union difference x_or intersection
     do
-        echo $type $filename
-        $1 -t $type ./tests/fixtures/clip-clockwise-square.json ./tests/geometry-test-data/input-polyjson/$filename > ./tests/output-polyjson/$type-$filename
+        $TESTER -t $type \
+            ./tests/fixtures/clip-clockwise-square.json \
+            ./tests/geometry-test-data/input-polyjson/$filename \
+            1>./tests/output-polyjson/$type-$filename;
+
+        # Check exit code of last command
+        if [ "$?" -eq "0" ]; then
+            PASSES=$((PASSES + 1))
+        else
+            echo $type $filename
+            FAILS=$((FAILS + 1))
+        fi
     done
 done
+
+TOTAL=$((PASSES + FAILS))
+echo -e "\033[1;32m ✓ $PASSES/$TOTAL \033[0;31m ✗ $FAILS/$TOTAL \033[0m"
+if [ "$FAILS" -gt "1" ]; then 
+    exit 1;
+fi
+

--- a/tests/run-geometry-tests.sh
+++ b/tests/run-geometry-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ./tests/run-geometry-tests.sh ./fixture-tester
 TESTER="$1"

--- a/tests/run-geometry-tests.sh
+++ b/tests/run-geometry-tests.sh
@@ -37,7 +37,7 @@ done
 
 TOTAL=$((PASSES + FAILS))
 echo -e "\033[1;32m ✓ $PASSES/$TOTAL \033[0;31m ✗ $FAILS/$TOTAL \033[0m"
-if [ "$FAILS" -gt "1" ]; then 
+if [ "$FAILS" -gt "0" ]; then 
     exit 1;
 fi
 


### PR DESCRIPTION
- catch missing fixture-tester and report it when running `run-geometry-tests.sh`
- output pass/fail numbers for `run-geometry-tests.sh`
- use non-zero exit codes for failure so we could hook up geometry tests in travis