### PR TITLE
Add makefile target to display coverage locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ debug: build-debug build-fixture-tester
 	./test
 	./tests/run-geometry-tests.sh ./fixture-tester
 
+coverage: Makefile
+	./scripts/coverage.sh
+
 fuzzer: build-fuzzer
 	./fuzzer
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+# http://clang.llvm.org/docs/UsersManual.html#profiling-with-instrumentation
+# https://www.bignerdranch.com/blog/weve-got-you-covered/
+
+MASON_BASE=$(pwd)
+.mason/mason install clang++ 3.9.0
+.mason/mason link clang++ 3.9.0
+.mason/mason install llvm-cov 3.9.0
+.mason/mason link llvm-cov 3.9.0
+export CXX="${MASON_BASE}/mason_packages/.link/bin/clang++"
+export CXXFLAGS="-fprofile-instr-generate -fcoverage-mapping"
+export LDFLAGS="-fprofile-instr-generate"
+export LLVM_PROFILE_FILE="code-%p.profraw"
+make debug
+rm -f *profdata
+echo "merging results"
+${MASON_BASE}/mason_packages/.link/bin/llvm-profdata merge -output=code.profdata code-*.profraw
+${MASON_BASE}/mason_packages/.link/bin/llvm-cov report ./fixture-tester -instr-profile=code.profdata -use-color
+${MASON_BASE}/mason_packages/.link/bin/llvm-cov report ./test -instr-profile=code.profdata -use-color
+${MASON_BASE}/mason_packages/.link/bin/llvm-cov show ./fixture-tester -instr-profile=code.profdata include/mapbox/geometry/wagyu/*hpp -filename-equivalence -use-color --format html > /tmp/fixture-tester-coverage.html
+open /tmp/fixture-tester-coverage.html
+${MASON_BASE}/mason_packages/.link/bin/llvm-cov show ./test -instr-profile=code.profdata include/mapbox/geometry/wagyu/*hpp -filename-equivalence -use-color --format html > /tmp/test-coverage.html
+open /tmp/test-coverage.html
+echo "open /tmp/fixture-tester-coverage.html and /tmp/test-coverate.html for HTML version of this report"
+rm -f *profraw
+rm -f *gcov


### PR DESCRIPTION
/cc @flippmoke - this uses latest llvm 3.9.0 release to display coverage reports locally. It dumps a summary to the terminal and then creates line-by-line reports as html and opens these in your browser. Can you try testing? Just run: `make coverage`

More details on how this works: https://github.com/mapbox/cpp#using-profile-coverage-format

Current limitations:

  - Because of the way the fixture-tester is launched lots of separate coverage files are created and need to be merged: this is very slow
  - Not able to filter out results in summaries from third party headers -ability to filter is coming in > 3.9.0: https://llvm.org/bugs/show_bug.cgi?id=30659
  - Llvm-cov show warns about uncovered files - this will be fixed soon: https://llvm.org/bugs/show_bug.cgi?id=30659