### PR TITLE
Update versions + test more on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,61 +4,61 @@ sudo: false
 matrix:
   include:
     - os: linux
-      env: CXX=g++-4.9 BUILDTYPE=Release
+      env: CXX=g++-4.9
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-4.9' ]
     - os: linux
-      env: CXX=g++-5 BUILDTYPE=Release
+      env: CXX=g++-5
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-5' ]
     - os: linux
-      env: CXX=g++-6 BUILDTYPE=Release
+      env: CXX=g++-6
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-6' ]
     - os: linux
-      env: CXX=clang++ BUILDTYPE=Release CXXFLAGS="-flto"
+      env: CXX=clang++ CXXFLAGS="-flto"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
     - os: linux
-      env: CXX=clang++ CLANG_VERSION="4.0.0" BUILDTYPE=Release CXXFLAGS="-flto"
+      env: CXX=clang++ CLANG_VERSION="4.0.0" CXXFLAGS="-flto"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
     - os: linux
-      env: CXX=clang++ BUILDTYPE=Debug CXXFLAGS="-flto -fsanitize=cfi -fvisibility=hidden"
+      env: CXX=clang++ CXXFLAGS="-flto -fsanitize=cfi -fvisibility=hidden"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
     - os: linux
-      env: CXX=clang++ BUILDTYPE=Debug CXXFLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-common"
+      env: CXX=clang++ CXXFLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-common"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
     - os: linux
-      env: CXX=clang++ BUILDTYPE=Debug CXXFLAGS="-fsanitize=undefined"
+      env: CXX=clang++ CXXFLAGS="-fsanitize=undefined"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
     - os: linux
-      env: CXX=clang++ BUILDTYPE=Debug CXXFLAGS="-fsanitize=integer"
+      env: CXX=clang++ CXXFLAGS="-fsanitize=integer"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
     - os: linux
-      env: CXX=clang++ BUILDTYPE=Debug COVERAGE=true CXXFLAGS="--coverage"
+      env: CXX=clang++ COVERAGE=true CXXFLAGS="--coverage"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
@@ -80,12 +80,9 @@ before_install:
    fi
 
 script:
- - |
-   if [[ ${BUILDTYPE} == 'Debug' ]]; then
-     make debug
-   else
-     make test
-   fi
+ - make debug
+ - make clean
+ - make test
  - |
    if [[ ${COVERAGE} == 'true' ]]; then
      which llvm-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,9 @@ before_install:
    fi
 
 script:
- - make debug
- - make clean
  - make test
+ - make clean
+ - make debug
  - |
    if [[ ${COVERAGE} == 'true' ]]; then
      which llvm-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: generic
 sudo: false
 
+default_script: &run_script
+
+script: *run_script
+
 matrix:
   include:
     - os: linux
@@ -9,62 +13,81 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-4.9' ]
+      script: *run_script
     - os: linux
       env: CXX=g++-5
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-5' ]
+      script: *run_script
     - os: linux
       env: CXX=g++-6
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-6' ]
+      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-flto"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
+      script: *run_script
     - os: linux
       env: CXX=clang++ CLANG_VERSION="4.0.0" CXXFLAGS="-flto"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
+      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-flto -fsanitize=cfi -fvisibility=hidden"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
+      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-common"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
+      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-fsanitize=undefined"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
+      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-fsanitize=integer"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
+      script: *run_script
+    - os: osx
+      osx_image: xcode7.3
+      script: *run_script
     - os: linux
       env: CXX=clang++ COVERAGE=true CXXFLAGS="--coverage"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
-    - os: osx
-      osx_image: xcode7.3
+      script:
+       - make debug
+       - |
+         if [[ ${COVERAGE} == 'true' ]]; then
+           which llvm-cov
+           curl -S -f https://codecov.io/bash -o codecov
+           chmod +x codecov
+           ./codecov -x "llvm-cov gcov" -Z
+         fi
 
 cache: apt
 
@@ -77,16 +100,4 @@ before_install:
     export PATH=$(./.mason/mason prefix clang++ ${CLANG_VERSION})/bin:${PATH}
     ./.mason/mason install binutils 2.27
     export PATH=$(./.mason/mason prefix binutils 2.27)/bin:${PATH}
-   fi
-
-script:
- - make test
- - make clean
- - make debug
- - |
-   if [[ ${COVERAGE} == 'true' ]]; then
-     which llvm-cov
-     curl -S -f https://codecov.io/bash -o codecov
-     chmod +x codecov
-     ./codecov -x "llvm-cov gcov" -Z
    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,12 @@ matrix:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
     - os: linux
+      env: CXX=clang++ CLANG_VERSION="4.0.0" BUILDTYPE=Release CXXFLAGS="-flto"
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++6','libstdc++-5-dev' ]
+    - os: linux
       env: CXX=clang++ BUILDTYPE=Debug CXXFLAGS="-flto -fsanitize=cfi -fvisibility=hidden"
       addons:
         apt:
@@ -66,8 +72,9 @@ before_install:
  - git submodule update --init
  - |
    if [[ ${CXX} == "clang++" ]]; then
-    ./.mason/mason install clang++ 3.9.0
-    export PATH=$(./.mason/mason prefix clang++ 3.9.0)/bin:${PATH}
+    CLANG_VERSION="${CLANG_VERSION:-3.9.1}"
+    ./.mason/mason install clang++ ${CLANG_VERSION}
+    export PATH=$(./.mason/mason prefix clang++ ${CLANG_VERSION})/bin:${PATH}
     ./.mason/mason install binutils 2.27
     export PATH=$(./.mason/mason prefix binutils 2.27)/bin:${PATH}
    fi

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ $(MASON):
 	git submodule update --init
 
 mason_packages/.link/include/boost: $(MASON)
-	$(MASON) install boost 1.61.0 && $(MASON) link boost 1.61.0
+	$(MASON) install boost 1.63.0 && $(MASON) link boost 1.63.0
 
 mason_packages/.link/include/rapidjson: $(MASON)
 	$(MASON) install rapidjson 1.0.2 && $(MASON) link rapidjson 1.0.2
 
 mason_packages/.link/include/mapbox/geometry.hpp: $(MASON)
-	$(MASON) install geometry 0.7.0 && $(MASON) link geometry 0.7.0
+	$(MASON) install geometry 0.9.0 && $(MASON) link geometry 0.9.0
 
 deps: mason_packages/.link/include/rapidjson mason_packages/.link/include/mapbox/geometry.hpp mason_packages/.link/include/boost
 


### PR DESCRIPTION
This PR:

 - Updates to clang++ 3.9.1 (3.9.0 has known bugs)
 - Also starts testing on clang++ 4.0 (maybe 4.0 will catch bugs through new warnings, etc)
 - Updated to latest boost and geometry.hpp
 - Starts testing both debug and release version on travis (why not test more?)