### PR TITLE
Add -Weffc++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC := $(CC)
 CXX := $(CXX)
 CXXFLAGS := $(CXXFLAGS) -Iinclude -isystem mason_packages/.link/include -std=c++11
 RELEASE_FLAGS := -O3 -DNDEBUG
-WARNING_FLAGS := -Wall -Wextra -Werror -Wsign-compare -Wfloat-equal -Wfloat-conversion -Wshadow -Wno-unsequenced
+WARNING_FLAGS := -Wall -Wextra -Weffc++ -Werror -Wsign-compare -Wfloat-equal -Wfloat-conversion -Wshadow -Wno-unsequenced
 DEBUG_FLAGS := -g -O0 -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
 MASON ?= .mason/mason
 CLIPPER_REVISION=ac8d6bf2517f46c05647b5c19cac113fb180ffb4


### PR DESCRIPTION
Adding this warning will prevent bugs like #69 in the future from passing on travis.

From the gcc docs (https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html):

#### -Weffc++ (C++ and Objective-C++ only)

Warn about violations of the following style guidelines from Scott Meyers' Effective C++ series of books:
 - Define a copy constructor and an assignment operator for classes with dynamically-allocated memory.
 - Prefer initialization to assignment in constructors.
 - Have operator= return a reference to *this.
 - Don't try to return a reference when you must return an object.
 - Distinguish between prefix and postfix forms of increment and decrement operators.
 - Never overload &&, ||, or ,.

This option also enables -Wnon-virtual-dtor, which is also one of the effective C++ recommendations. However, the check is extended to warn about the lack of virtual destructor in accessible non-polymorphic bases classes too.

When selecting this option, be aware that the standard library headers do not obey all of these guidelines; use ‘grep -v’ to filter out those warnings. 

```