### PR TITLE
Fix travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,66 +10,79 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-4.9' ]
+      # override before_install to use apt installed compiler
+      # rather than mason installed clang++
+      before_install:
+        - which ${CXX}
     - os: linux
       env: CXX=g++-5
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-5' ]
+      # override before_install to use apt installed compiler
+      # rather than mason installed clang++
+      before_install:
+        - which ${CXX}
     - os: linux
       env: CXX=g++-6
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-6' ]
+      # override before_install to use apt installed compiler
+      # rather than mason installed clang++
+      before_install:
+        - which ${CXX}
     - os: linux
       env: CXX=clang++ CXXFLAGS="-flto"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6','libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
     - os: linux
       env: CXX=clang++ LLVM_VERSION="4.0.0" CXXFLAGS="-flto"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6','libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
     - os: linux
       env: CXX=clang++ CXXFLAGS="-flto -fsanitize=cfi -fvisibility=hidden"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6','libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
     - os: linux
       env: CXX=clang++ CXXFLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-common"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6','libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
     - os: linux
       env: CXX=clang++ CXXFLAGS="-fsanitize=undefined"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6','libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
     - os: linux
       env: CXX=clang++ CXXFLAGS="-fsanitize=integer"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6','libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
     - os: osx
       osx_image: xcode7.3
     - os: linux
-      env: CXX=clang++ LLVM_VERSION="3.9.1" COVERAGE=true CXXFLAGS="--coverage"
+      env: CXX=clang++ COVERAGE=true CXXFLAGS="--coverage"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++6','libstdc++-5-dev' ]
+          packages: [ 'libstdc++-5-dev' ]
+      # override before_script to run coverage
       before_script:
        - make debug
-       - ./.mason/mason install llvm-cov ${LLVM_VERSION}
-       - export PATH=$(./.mason/mason prefix llvm-cov ${LLVM_VERSION})/bin:${PATH}
+       - ./.mason/mason install llvm-cov 3.9.1
+       - export PATH=$(./.mason/mason prefix llvm-cov 3.9.1)/bin:${PATH}
        - which llvm-cov
        - curl -S -f https://codecov.io/bash -o codecov
        - chmod +x codecov
@@ -77,6 +90,7 @@ matrix:
 
 before_install:
  - git submodule update --init
+ - export LLVM_VERSION="${LLVM_VERSION:-3.9.1}"
  - |
    if [[ ${CXX} == "clang++" ]]; then
     ./mason.sh install clang++ ${LLVM_VERSION}
@@ -84,6 +98,7 @@ before_install:
     ./mason.sh install binutils 2.27
     export PATH=$(./mason.sh prefix binutils 2.27)/bin:${PATH}
    fi
+ - which ${CXX}
 
 before_script:
  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,8 @@ matrix:
       # override before_script to run coverage
       before_script:
        - make debug
-       - ./.mason/mason install llvm-cov 3.9.1
-       - export PATH=$(./.mason/mason prefix llvm-cov 3.9.1)/bin:${PATH}
+       - ./mason.sh install llvm-cov 3.9.1
+       - export PATH=$(./mason.sh prefix llvm-cov 3.9.1)/bin:${PATH}
        - which llvm-cov
        - curl -S -f https://codecov.io/bash -o codecov
        - chmod +x codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++-5-dev' ]
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8.2
       env: CXX=clang++
     - os: linux
       env: CXX=clang++ COVERAGE=true CXXFLAGS="--coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: generic
+
 sudo: false
-
-default_script: &run_script
-
-script: *run_script
 
 matrix:
   include:
@@ -13,91 +10,83 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-4.9' ]
-      script: *run_script
     - os: linux
       env: CXX=g++-5
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-5' ]
-      script: *run_script
     - os: linux
       env: CXX=g++-6
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-6' ]
-      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-flto"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
-      script: *run_script
     - os: linux
-      env: CXX=clang++ CLANG_VERSION="4.0.0" CXXFLAGS="-flto"
+      env: CXX=clang++ LLVM_VERSION="4.0.0" CXXFLAGS="-flto"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
-      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-flto -fsanitize=cfi -fvisibility=hidden"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
-      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-common"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
-      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-fsanitize=undefined"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
-      script: *run_script
     - os: linux
       env: CXX=clang++ CXXFLAGS="-fsanitize=integer"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
-      script: *run_script
     - os: osx
       osx_image: xcode7.3
-      script: *run_script
     - os: linux
-      env: CXX=clang++ COVERAGE=true CXXFLAGS="--coverage"
+      env: CXX=clang++ LLVM_VERSION="3.9.1" COVERAGE=true CXXFLAGS="--coverage"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++6','libstdc++-5-dev' ]
-      script:
+      before_script:
        - make debug
-       - |
-         if [[ ${COVERAGE} == 'true' ]]; then
-           which llvm-cov
-           curl -S -f https://codecov.io/bash -o codecov
-           chmod +x codecov
-           ./codecov -x "llvm-cov gcov" -Z
-         fi
-
-cache: apt
+       - ./.mason/mason install llvm-cov ${LLVM_VERSION}
+       - export PATH=$(./.mason/mason prefix llvm-cov ${LLVM_VERSION})/bin:${PATH}
+       - which llvm-cov
+       - curl -S -f https://codecov.io/bash -o codecov
+       - chmod +x codecov
+       - ./codecov -x "llvm-cov gcov" -Z
 
 before_install:
  - git submodule update --init
  - |
    if [[ ${CXX} == "clang++" ]]; then
-    CLANG_VERSION="${CLANG_VERSION:-3.9.1}"
-    ./mason.sh install clang++ ${CLANG_VERSION}
-    export PATH=$(./mason.sh prefix clang++ ${CLANG_VERSION})/bin:${PATH}
+    ./mason.sh install clang++ ${LLVM_VERSION}
+    export PATH=$(./mason.sh prefix clang++ ${LLVM_VERSION})/bin:${PATH}
     ./mason.sh install binutils 2.27
     export PATH=$(./mason.sh prefix binutils 2.27)/bin:${PATH}
    fi
+
+before_script:
+ - make test
+ - make clean
+ - make debug
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
       osx_image: xcode7.3
       env: CXX=clang++
       # override before_install to use apple clang
-      brefore_install:
+      before_install:
         - which ${CXX}
     # OS X / mason clang 4.0.0 / xcode 8.x
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ matrix:
           packages: [ 'libstdc++-5-dev' ]
     - os: osx
       osx_image: xcode7.3
+      env: CXX=clang++
     - os: linux
       env: CXX=clang++ COVERAGE=true CXXFLAGS="--coverage"
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,17 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'libstdc++-5-dev' ]
+    # OS X / apple clang / xcode 7.x
+    - os: osx
+      osx_image: xcode7.3
+      env: CXX=clang++
+      # override before_install to use apple clang
+      brefore_install:
+        - which ${CXX}
+    # OS X / mason clang 4.0.0 / xcode 8.x
     - os: osx
       osx_image: xcode8.2
-      env: CXX=clang++
+      env: CXX=clang++ LLVM_VERSION="4.0.0"
     - os: linux
       env: CXX=clang++ COVERAGE=true CXXFLAGS="--coverage"
       addons:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CC := $(CC)
 CXX := $(CXX)
 CXXFLAGS := $(CXXFLAGS) -Iinclude -isystem mason_packages/headers/boost/$(BOOST_VERSION)/include -isystem mason_packages/headers/rapidjson/$(RAPIDJSON_VERSION)/include -isystem mason_packages/headers/geometry/$(GEOMETRY_VERSION)/include -std=c++11
 RELEASE_FLAGS := -O3 -DNDEBUG
-WARNING_FLAGS := -Wall -Wextra -Weffc++ -Werror -Wsign-compare -Wfloat-equal -Wconversion -Wshadow
+WARNING_FLAGS := -Wall -Wextra -Weffc++ -Werror -Wsign-compare -Wfloat-equal -Wshadow
 DEBUG_FLAGS := -g -O0 -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
 CLIPPER_REVISION=ac8d6bf2517f46c05647b5c19cac113fb180ffb4
 ANGUS_DEFINES := -D'CLIPPER_INTPOINT_IMPL=mapbox::geometry::point<cInt>' -D'CLIPPER_PATH_IMPL=mapbox::geometry::linear_ring<cInt>' -D'CLIPPER_PATHS_IMPL=mapbox::geometry::polygon<cInt>' -D'CLIPPER_IMPL_INCLUDE=<mapbox/geometry/polygon.hpp>'

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CC := $(CC)
 CXX := $(CXX)
 CXXFLAGS := $(CXXFLAGS) -Iinclude -isystem mason_packages/headers/boost/$(BOOST_VERSION)/include -isystem mason_packages/headers/rapidjson/$(RAPIDJSON_VERSION)/include -isystem mason_packages/headers/geometry/$(GEOMETRY_VERSION)/include -std=c++11
 RELEASE_FLAGS := -O3 -DNDEBUG
-WARNING_FLAGS := -Wall -Wextra -Weffc++ -Werror -Wsign-compare -Wfloat-equal -Wfloat-conversion -Wshadow -Wno-unsequenced -Wshorten-64-to-32 -Wsign-conversion -Wno-error=unknown-warning
+WARNING_FLAGS := -Wall -Wextra -Weffc++ -Werror -Wsign-compare -Wfloat-equal -Wfloat-conversion -Wshadow -Wno-unsequenced -Wsign-conversion
 DEBUG_FLAGS := -g -O0 -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
 CLIPPER_REVISION=ac8d6bf2517f46c05647b5c19cac113fb180ffb4
 ANGUS_DEFINES := -D'CLIPPER_INTPOINT_IMPL=mapbox::geometry::point<cInt>' -D'CLIPPER_PATH_IMPL=mapbox::geometry::linear_ring<cInt>' -D'CLIPPER_PATHS_IMPL=mapbox::geometry::polygon<cInt>' -D'CLIPPER_IMPL_INCLUDE=<mapbox/geometry/polygon.hpp>'

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CC := $(CC)
 CXX := $(CXX)
 CXXFLAGS := $(CXXFLAGS) -Iinclude -isystem mason_packages/headers/boost/$(BOOST_VERSION)/include -isystem mason_packages/headers/rapidjson/$(RAPIDJSON_VERSION)/include -isystem mason_packages/headers/geometry/$(GEOMETRY_VERSION)/include -std=c++11
 RELEASE_FLAGS := -O3 -DNDEBUG
-WARNING_FLAGS := -Wall -Wextra -Weffc++ -Werror -Wsign-compare -Wfloat-equal -Wfloat-conversion -Wshadow -Wno-unsequenced -Wsign-conversion
+WARNING_FLAGS := -Wall -Wextra -Weffc++ -Werror -Wsign-compare -Wfloat-equal -Wconversion -Wshadow
 DEBUG_FLAGS := -g -O0 -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
 CLIPPER_REVISION=ac8d6bf2517f46c05647b5c19cac113fb180ffb4
 ANGUS_DEFINES := -D'CLIPPER_INTPOINT_IMPL=mapbox::geometry::point<cInt>' -D'CLIPPER_PATH_IMPL=mapbox::geometry::linear_ring<cInt>' -D'CLIPPER_PATHS_IMPL=mapbox::geometry::polygon<cInt>' -D'CLIPPER_IMPL_INCLUDE=<mapbox/geometry/polygon.hpp>'

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CC := $(CC)
 CXX := $(CXX)
 CXXFLAGS := $(CXXFLAGS) -Iinclude -isystem mason_packages/headers/boost/$(BOOST_VERSION)/include -isystem mason_packages/headers/rapidjson/$(RAPIDJSON_VERSION)/include -isystem mason_packages/headers/geometry/$(GEOMETRY_VERSION)/include -std=c++11
 RELEASE_FLAGS := -O3 -DNDEBUG
-WARNING_FLAGS := -Wall -Wextra -Weffc++ -Werror -Wsign-compare -Wfloat-equal -Wfloat-conversion -Wshadow -Wno-unsequenced -Wshorten-64-to-32 -Wsign-conversion
+WARNING_FLAGS := -Wall -Wextra -Weffc++ -Werror -Wsign-compare -Wfloat-equal -Wfloat-conversion -Wshadow -Wno-unsequenced -Wshorten-64-to-32 -Wsign-conversion -Wno-error=unknown-warning
 DEBUG_FLAGS := -g -O0 -DDEBUG -fno-inline-functions -fno-omit-frame-pointer
 CLIPPER_REVISION=ac8d6bf2517f46c05647b5c19cac113fb180ffb4
 ANGUS_DEFINES := -D'CLIPPER_INTPOINT_IMPL=mapbox::geometry::point<cInt>' -D'CLIPPER_PATH_IMPL=mapbox::geometry::linear_ring<cInt>' -D'CLIPPER_PATHS_IMPL=mapbox::geometry::polygon<cInt>' -D'CLIPPER_IMPL_INCLUDE=<mapbox/geometry/polygon.hpp>'

--- a/include/mapbox/geometry/wagyu/bound.hpp
+++ b/include/mapbox/geometry/wagyu/bound.hpp
@@ -64,6 +64,10 @@ struct bound {
           poly_type(std::move(b.poly_type)),
           side(std::move(b.side)) {
     }
+
+    bound(bound<T>const& b) = delete;
+    bound<T>& operator=(bound<T> const&) = delete;
+
 };
 
 #ifdef DEBUG

--- a/tests/fixture-tester.cpp
+++ b/tests/fixture-tester.cpp
@@ -18,8 +18,8 @@ struct Options {
     std::size_t iterations = 1;
     clip_type operation = clip_type_union;
     fill_type fill = fill_type_even_odd;
-    char* subject_file;
-    char* clip_file;
+    char* subject_file = nullptr;
+    char* clip_file = nullptr;
 } options;
 
 void log_ring(mapbox::geometry::polygon<std::int64_t> const& p) {
@@ -169,7 +169,7 @@ void parse_options(int argc, char* const argv[]) {
         } else {
             // If we didn't catch this argument as a flag or a flag value,
             // set the input files
-            if (options.subject_file == NULL) {
+            if (options.subject_file == nullptr) {
                 options.subject_file = argv[i];
             } else {
                 options.clip_file = argv[i];
@@ -192,7 +192,7 @@ int main(int argc, char* const argv[]) {
     auto poly_subject = parse_file(options.subject_file);
     mapbox::geometry::polygon<value_type> poly_clip;
     mapbox::geometry::multi_polygon<value_type> solution;
-    if (options.clip_file != NULL) {
+    if (options.clip_file != nullptr) {
         poly_clip = parse_file(options.clip_file);
     }
     while (options.iterations > 0) {


### PR DESCRIPTION
Per https://github.com/mapbox/wagyu/pull/63#issuecomment-287227622, travis tests have not been working. Sorry.

The outcome of this is that the warnings we've added recently like `-Weffc++` (#70), `-Wsign-conversion` (https://github.com/mapbox/wagyu/commit/92d8ef5974316f60c33556c611d18691659bd87e), and `-Wshorten-64-to-32` (https://github.com/mapbox/wagyu/commit/684a19c3ffb2e4ce5e9f8786d16bdf48fa23ee5e) have been creating errors without failing travis.

This PR fixes travis to properly run the tests and post coverage. It also fixes a few of the new warnings issues. Others I've ticketed separately since they require more involved code changes to fix, see #74.
