### PR TITLE
Analysis of wagyu source code by PVS-Studio

### DIFF
--- a/include/mapbox/geometry/wagyu/ring_util.hpp
+++ b/include/mapbox/geometry/wagyu/ring_util.hpp
@@ -379,7 +379,7 @@ inline double get_dx(point<T> const& pt1, point<T> const& pt2) {
     if (pt1.y == pt2.y) {
         return std::numeric_limits<double>::infinity();
     } else {
-        return static_cast<double>(pt2.x - pt2.x) / static_cast<double>(pt2.y - pt1.y);
+        return static_cast<double>(pt2.x - pt1.x) / static_cast<double>(pt2.y - pt1.y);
     }
 }
 


### PR DESCRIPTION
To demonstrate the abilities of PVS-Studio analyzer, we decided to find several bugs.
I would like to suggest a variant of the way to fix the error, detected with the help of V501 diagnostic: There are identical sub-expressions to the left and to the right of the '-' operator: pt2.x - pt2.x

PVS-Studio is a tool for bug detection in the source code of programs, written in C, C++ and C#. It works in Windows and Linux environment. https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.