### PR TITLE
std::round is not defined in some platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,7 @@
 - Fixed bug in `get_dx`
 - Fixed some includes that were missing in some headers
 - Removed some dead code paths and checks that are no longer required
+
+## 0.4.3
+
+- Use `::llround()` instead of `std::llround()` for old libstdc++ compatibility.

--- a/include/mapbox/geometry/wagyu/util.hpp
+++ b/include/mapbox/geometry/wagyu/util.hpp
@@ -73,12 +73,12 @@ bool slopes_equal(mapbox::geometry::point<T> const& pt1,
 
 template <typename T>
 inline T wround(double value) {
-    return static_cast<T>(std::llround(value));
+    return static_cast<T>(::llround(value));
 }
 
 template <>
 inline std::int64_t wround<std::int64_t>(double value) {
-    return std::llround(value);
+    return ::llround(value);
 }
 }
 }

--- a/include/mapbox/geometry/wagyu/wagyu.hpp
+++ b/include/mapbox/geometry/wagyu/wagyu.hpp
@@ -17,7 +17,7 @@
 
 #define WAGYU_MAJOR_VERSION 0
 #define WAGYU_MINOR_VERSION 4
-#define WAGYU_PATCH_VERSION 2
+#define WAGYU_PATCH_VERSION 3
 
 #define WAGYU_VERSION                                                                              \
     (WAGYU_MAJOR_VERSION * 100000) + (WAGYU_MINOR_VERSION * 100) + (WAGYU_PATCH_VERSION)


### PR DESCRIPTION
Use the C version.

Fixes build on Android + GCC.