### PR TITLE
Add noexcept to intersect_node

### DIFF
--- a/include/mapbox/geometry/wagyu/intersect.hpp
+++ b/include/mapbox/geometry/wagyu/intersect.hpp
@@ -21,11 +21,11 @@ struct intersect_node {
     bound_ptr<T> bound2;
     mapbox::geometry::point<double> pt;
 
-    intersect_node(intersect_node<T>&& n)
+    intersect_node(intersect_node<T>&& n) noexcept
         : bound1(std::move(n.bound1)), bound2(std::move(n.bound2)), pt(std::move(n.pt)) {
     }
 
-    intersect_node& operator=(intersect_node<T>&& n) {
+    intersect_node& operator=(intersect_node<T>&& n)  noexcept {
         bound1 = std::move(n.bound1);
         bound2 = std::move(n.bound2);
         pt = std::move(n.pt);


### PR DESCRIPTION
Noticed the move constructor and move assignment operator were not marked `noexcept`.