### PR TITLE
Use LLVM for testing on travis

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,8 @@
 set -eu
 set -o pipefail
 
-export MASON_RELEASE="${_MASON_RELEASE:-v0.18.0}"
-export MASON_LLVM_RELEASE="${_MASON_LLVM_RELEASE:-5.0.1}"
+export MASON_RELEASE="${_MASON_RELEASE:-v0.19.0}"
+export MASON_LLVM_RELEASE="${_MASON_LLVM_RELEASE:-7.0.0}"
 
 PLATFORM=$(uname | tr A-Z a-z)
 if [[ ${PLATFORM} == 'darwin' ]]; then


### PR DESCRIPTION
@flippmoke this queues up a PR that uses LLVM 7. LLVM 7 brings in a lot more clang-tidy checks, so that job is failing. I put this up as a gut check that LLVM 7 is looking good for hpp-skel projects. My take is that it is, so I'm going to stop here and let you fix the clang-tidy warnings and merge this when you have time.