### PR TITLE
Travis coverage: Avoid overwritting coverage files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         - mason link llvm-cov ${MASON_LLVM_RELEASE}
         - curl -S -f https://codecov.io/bash -o codecov
         - chmod +x codecov
-        - ./codecov -x "llvm-cov gcov" -Z
+        - ./codecov -x "llvm-cov gcov -l" -Z
 
 env:
   global:


### PR DESCRIPTION
After some investigation I think that the issue behind the coverage loss is that the coverage files are being overwritten when several binaries are executed, so only the last is reported.

To avoid this I've added the [`-l` flag](https://llvm.org/docs/CommandGuide/llvm-cov.html):
```
-l, --long-file-names
For coverage output of files included from the main source file, add the main file name followed by ## as a prefix to the output file names. This can be combined with the –preserve-paths option to use complete paths for both the main file and the included file.
```

Fixes https://github.com/mapbox/wagyu/issues/90