### PR TITLE
Scanbeam speedup

### DIFF
--- a/include/mapbox/geometry/wagyu/active_bound_list.hpp
+++ b/include/mapbox/geometry/wagyu/active_bound_list.hpp
@@ -152,7 +152,7 @@ void next_edge_in_bound(bound<T>& bnd, scanbeam_list<T>& scanbeam) {
         ++(bnd.next_edge);
         bnd.current_x = static_cast<double>(current_edge->bot.x);
         if (!is_horizontal<T>(*current_edge)) {
-            scanbeam.insert(current_edge->top.y);
+            insert_sorted_scanbeam(scanbeam, current_edge->top.y);
         }
     }
 }
@@ -345,10 +345,10 @@ void insert_lm_left_and_right_bound(bound<T>& left_bound,
     }
 
     // Add top of edges to scanbeam
-    scanbeam.insert((*lb_abl_itr)->current_edge->top.y);
+    insert_sorted_scanbeam(scanbeam, (*lb_abl_itr)->current_edge->top.y);
 
     if (!current_edge_is_horizontal<T>(rb_abl_itr)) {
-        scanbeam.insert((*rb_abl_itr)->current_edge->top.y);
+        insert_sorted_scanbeam(scanbeam, (*rb_abl_itr)->current_edge->top.y);
     }
 }
 

--- a/include/mapbox/geometry/wagyu/active_bound_list.hpp
+++ b/include/mapbox/geometry/wagyu/active_bound_list.hpp
@@ -152,7 +152,7 @@ void next_edge_in_bound(bound<T>& bnd, scanbeam_list<T>& scanbeam) {
         ++(bnd.next_edge);
         bnd.current_x = static_cast<double>(current_edge->bot.x);
         if (!is_horizontal<T>(*current_edge)) {
-            scanbeam.push_back(current_edge->top.y);
+            scanbeam.insert(current_edge->top.y);
         }
     }
 }
@@ -345,10 +345,10 @@ void insert_lm_left_and_right_bound(bound<T>& left_bound,
     }
 
     // Add top of edges to scanbeam
-    scanbeam.push_back((*lb_abl_itr)->current_edge->top.y);
+    scanbeam.insert((*lb_abl_itr)->current_edge->top.y);
 
     if (!current_edge_is_horizontal<T>(rb_abl_itr)) {
-        scanbeam.push_back((*rb_abl_itr)->current_edge->top.y);
+        scanbeam.insert((*rb_abl_itr)->current_edge->top.y);
     }
 }
 

--- a/include/mapbox/geometry/wagyu/scanbeam.hpp
+++ b/include/mapbox/geometry/wagyu/scanbeam.hpp
@@ -4,14 +4,21 @@
 #include <mapbox/geometry/wagyu/local_minimum.hpp>
 
 #include <algorithm>
-#include <iterator>
 
 namespace mapbox {
 namespace geometry {
 namespace wagyu {
 
 template <typename T>
-using scanbeam_list = std::set<T>;
+using scanbeam_list = std::vector<T>;
+
+template <typename T>
+void insert_sorted_scanbeam(scanbeam_list<T>& scanbeam, T& t) {
+    typename scanbeam_list<T>::iterator i = std::lower_bound(scanbeam.begin(), scanbeam.end(), t);
+    if (i == scanbeam.end() || t < *i) {
+        scanbeam.insert(i, t);
+    }
+}
 
 template <typename T>
 bool pop_from_scanbeam(T& Y, scanbeam_list<T>& scanbeam) {
@@ -19,18 +26,19 @@ bool pop_from_scanbeam(T& Y, scanbeam_list<T>& scanbeam) {
         return false;
     }
 
-    auto back = std::prev(scanbeam.end());
-    Y = *back;
-    scanbeam.erase(back);
+    Y = scanbeam.back();
+    scanbeam.pop_back();
     return true;
 }
 
 template <typename T>
 void setup_scanbeam(local_minimum_list<T>& minima_list, scanbeam_list<T>& scanbeam) {
 
+    scanbeam.reserve(minima_list.size());
     for (auto lm = minima_list.begin(); lm != minima_list.end(); ++lm) {
-        scanbeam.insert(lm->y);
+        scanbeam.push_back(lm->y);
     }
+    std::sort(scanbeam.begin(), scanbeam.end());
 }
 } // namespace wagyu
 } // namespace geometry

--- a/include/mapbox/geometry/wagyu/scanbeam.hpp
+++ b/include/mapbox/geometry/wagyu/scanbeam.hpp
@@ -4,23 +4,24 @@
 #include <mapbox/geometry/wagyu/local_minimum.hpp>
 
 #include <algorithm>
+#include <iterator>
 
 namespace mapbox {
 namespace geometry {
 namespace wagyu {
 
 template <typename T>
-using scanbeam_list = std::vector<T>;
+using scanbeam_list = std::set<T>;
 
 template <typename T>
 bool pop_from_scanbeam(T& Y, scanbeam_list<T>& scanbeam) {
     if (scanbeam.empty()) {
         return false;
     }
-    std::sort(scanbeam.begin(), scanbeam.end());
-    scanbeam.erase(std::unique(scanbeam.begin(), scanbeam.end()), scanbeam.end());
-    Y = scanbeam.back();
-    scanbeam.pop_back();
+
+    auto back = std::prev(scanbeam.end());
+    Y = *back;
+    scanbeam.erase(back);
     return true;
 }
 
@@ -28,7 +29,7 @@ template <typename T>
 void setup_scanbeam(local_minimum_list<T>& minima_list, scanbeam_list<T>& scanbeam) {
 
     for (auto lm = minima_list.begin(); lm != minima_list.end(); ++lm) {
-        scanbeam.push_back(lm->y);
+        scanbeam.insert(lm->y);
     }
 }
 } // namespace wagyu

--- a/include/mapbox/geometry/wagyu/snap_rounding.hpp
+++ b/include/mapbox/geometry/wagyu/snap_rounding.hpp
@@ -141,11 +141,11 @@ void insert_local_minima_into_ABL_hot_pixel(T top_y,
         right_bound.current_x = static_cast<double>(right_bound.current_edge->bot.x);
         auto lb_abl_itr = insert_bound_into_ABL(left_bound, right_bound, active_bounds);
         if (!current_edge_is_horizontal<T>(lb_abl_itr)) {
-            scanbeam.push_back((*lb_abl_itr)->current_edge->top.y);
+            scanbeam.insert((*lb_abl_itr)->current_edge->top.y);
         }
         auto rb_abl_itr = std::next(lb_abl_itr);
         if (!current_edge_is_horizontal<T>(rb_abl_itr)) {
-            scanbeam.push_back((*rb_abl_itr)->current_edge->top.y);
+            scanbeam.insert((*rb_abl_itr)->current_edge->top.y);
         }
         ++lm;
     }

--- a/include/mapbox/geometry/wagyu/snap_rounding.hpp
+++ b/include/mapbox/geometry/wagyu/snap_rounding.hpp
@@ -141,11 +141,11 @@ void insert_local_minima_into_ABL_hot_pixel(T top_y,
         right_bound.current_x = static_cast<double>(right_bound.current_edge->bot.x);
         auto lb_abl_itr = insert_bound_into_ABL(left_bound, right_bound, active_bounds);
         if (!current_edge_is_horizontal<T>(lb_abl_itr)) {
-            scanbeam.insert((*lb_abl_itr)->current_edge->top.y);
+            insert_sorted_scanbeam(scanbeam, (*lb_abl_itr)->current_edge->top.y);
         }
         auto rb_abl_itr = std::next(lb_abl_itr);
         if (!current_edge_is_horizontal<T>(rb_abl_itr)) {
-            scanbeam.insert((*rb_abl_itr)->current_edge->top.y);
+            insert_sorted_scanbeam(scanbeam, (*rb_abl_itr)->current_edge->top.y);
         }
         ++lm;
     }


### PR DESCRIPTION
While testing the library under Postgis, I noticed that for certain geometries the time spent under std::sort was extremely high (40-70% of the total cpu instructions, measured with perf).

The geometries where I saw this behaviour were:
- A geometry from Canada region Nunavut with 1297243 points. Example tiles (webmercator): [0,0,0] and [3,2,1].
- A dataset with the continents, with North America as a 64823-points polygon and Asia with 41937. Example tile (webmercator): [4,5,5]. This is were it was way more noticeable.

Once I dig a little I saw that even though there are multiple sort and stable_sort calls in the library, the sole blamable function was `pop_from_scanbeam`. This function keeps the vector sorted, removes duplicates values and then returns the last one.

To avoid all this sorting I tried to keep 2 vectors so any addition would be done in a separate vector and then `pop_from_scanbeam` would only need to sort the additions and merged the 2. This improved the situation quite a bit in those special cases, but when running the microbenchmarks under `/bench` I was seeing ~5% slower times.

Then I noticed that keeping things sorted and without duplicates isn't well suited for `std::vector` since moving things around is pretty expensive. OTOH, `std::set` is much better in that case with the caveat that it's slower iterating over the whole array to read it completely. Since the algorithm only needs to read the last element,the bad scenario for `std::set` is avoided and things are pretty fast: I don't see any big difference in microbenchmarks (+-2% variances in any direction) but the improvement in the bad cases is even better (up to 5x faster): 
[20181228_big_mvt_wagyu_vs_20181228_big_mvt_wagyu_set.pdf](https://github.com/mapbox/wagyu/files/2715213/20181228_big_mvt_wagyu_vs_20181228_big_mvt_wagyu_set.pdf)


**NOTICE**: This is still a WIP. I intend to still have a look at the continents dataset since it's one of the places where the tiles are consistently slower with wagyu vs the previous postgis implementation (using GEOS). I decided to create the PR soon to receive any feedback or recommendations about things to test general performance or more cases.