### PR TITLE
Add interrupt mechanism

### DIFF
--- a/docs/building_and_testing.md
+++ b/docs/building_and_testing.md
@@ -49,6 +49,13 @@ Then, it will run the `fixture-tester` executable with all of the geometry tests
 
 You may want to use wagyu in your own project. Since wagyu is a header-only library, all you have to do is include `mapbox/geometry/polygon.hpp` and `mapbox/geometry/wagyu/wagyu.hpp`. `polygon.hpp` is the polygon portion of the Mapbox geometry library, a boost-compliant polygon geometry container.
 
+#### Enabling interruptions
+
+If you need support for interruptions within wagyu, you'll need to define `USE_WAGYU_INTERRUPT` before including `mapbox/geometry/wagyu/wagyu.hpp`. This will expose 3 functions:
+  - mapbox::geometry::wagyu::interrupt_reset: Resets any pending interruption call.
+  - mapbox::geometry::wagyu::interrupt_request: Requests the library to be interrupted.
+  - mapbox::geometry::wagyu::interrupt_check: Called internally to verify if an interruption is requested. Once the library notices a new request, the environment will be reset and a `std::runtime_error` thrown.
+
 ### Debugging
 
 `wagyu` has many `DEBUG` flags [throughout the code](https://github.com/mapbox/wagyu/blob/79d85c720c8fb9ab37d0b677ccf12f83d1015ad7/include/mapbox/geometry/wagyu/local_minimum.hpp#L56-L113) that will help you make sense of the library and what it is doing. To see log messages during execution of the code:

--- a/include/mapbox/geometry/wagyu/interrupt.hpp
+++ b/include/mapbox/geometry/wagyu/interrupt.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+/**
+ * To enable this by the program, define USE_WAGYU_INTERRUPT before including wagyu.hpp
+ * To request an interruption, call `interrupt_request()`. As soon as Wagyu detects the request
+ * it will raise an exception (`std::runtime_error`).
+ */
+
+#ifdef USE_WAGYU_INTERRUPT
+
+namespace {
+bool WAGYU_INTERRUPT_REQUESTED = false;
+}
+
+namespace mapbox {
+namespace geometry {
+namespace wagyu {
+
+static void interrupt_reset(void) {
+    WAGYU_INTERRUPT_REQUESTED = false;
+}
+
+static void interrupt_request(void) {
+    WAGYU_INTERRUPT_REQUESTED = true;
+}
+
+static void interrupt_check(void) {
+    if (WAGYU_INTERRUPT_REQUESTED) {
+        interrupt_reset();
+        throw std::runtime_error("Wagyu interrupted");
+    }
+}
+} // namespace wagyu
+} // namespace geometry
+} // namespace mapbox
+
+#else /* ! USE_WAGYU_INTERRUPT */
+
+namespace mapbox {
+namespace geometry {
+namespace wagyu {
+
+static void interrupt_check(void) {
+}
+
+} // namespace wagyu
+} // namespace geometry
+} // namespace mapbox
+
+#endif /* USE_WAGYU_INTERRUPT */

--- a/include/mapbox/geometry/wagyu/interrupt.hpp
+++ b/include/mapbox/geometry/wagyu/interrupt.hpp
@@ -9,7 +9,7 @@
 #ifdef USE_WAGYU_INTERRUPT
 
 namespace {
-bool WAGYU_INTERRUPT_REQUESTED = false;
+thread_local bool WAGYU_INTERRUPT_REQUESTED = false;
 }
 
 namespace mapbox {

--- a/include/mapbox/geometry/wagyu/local_minimum_util.hpp
+++ b/include/mapbox/geometry/wagyu/local_minimum_util.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mapbox/geometry/wagyu/edge.hpp>
+#include <mapbox/geometry/wagyu/interrupt.hpp>
 #include <mapbox/geometry/wagyu/local_minimum.hpp>
 
 #include <algorithm>
@@ -206,6 +207,7 @@ void add_ring_to_local_minima_list(edge_list<T>& edges, local_minimum_list<T>& m
     bound_ptr<T> first_minimum = nullptr;
     bound_ptr<T> last_maximum = nullptr;
     while (!edges.empty()) {
+        interrupt_check(); // Check for interruptions
         bool lm_minimum_has_horizontal = false;
         auto to_minimum = create_bound_towards_minimum(edges);
         if (edges.empty()) {

--- a/include/mapbox/geometry/wagyu/process_maxima.hpp
+++ b/include/mapbox/geometry/wagyu/process_maxima.hpp
@@ -3,6 +3,7 @@
 #include <mapbox/geometry/wagyu/active_bound_list.hpp>
 #include <mapbox/geometry/wagyu/config.hpp>
 #include <mapbox/geometry/wagyu/edge.hpp>
+#include <mapbox/geometry/wagyu/interrupt.hpp>
 #include <mapbox/geometry/wagyu/intersect_util.hpp>
 #include <mapbox/geometry/wagyu/local_minimum.hpp>
 #include <mapbox/geometry/wagyu/local_minimum_util.hpp>
@@ -65,6 +66,7 @@ void process_edges_at_top_of_scanbeam(T top_y,
                                       fill_type clip_fill_type) {
 
     for (auto bnd = active_bounds.begin(); bnd != active_bounds.end();) {
+        interrupt_check(); // Check for interruptions
         if (*bnd == nullptr) {
             ++bnd;
             continue;

--- a/include/mapbox/geometry/wagyu/wagyu.hpp
+++ b/include/mapbox/geometry/wagyu/wagyu.hpp
@@ -10,6 +10,7 @@
 #include <mapbox/geometry/wagyu/build_local_minima_list.hpp>
 #include <mapbox/geometry/wagyu/build_result.hpp>
 #include <mapbox/geometry/wagyu/config.hpp>
+#include <mapbox/geometry/wagyu/interrupt.hpp>
 #include <mapbox/geometry/wagyu/local_minimum.hpp>
 #include <mapbox/geometry/wagyu/snap_rounding.hpp>
 #include <mapbox/geometry/wagyu/topology_correction.hpp>
@@ -122,9 +123,15 @@ public:
 
         ring_manager<T> manager;
 
+        interrupt_check(); // Check for interruptions
+
         build_hot_pixels(minima_list, manager);
 
+        interrupt_check(); // Check for interruptions
+
         execute_vatti(minima_list, manager, cliptype, subject_fill_type, clip_fill_type);
+
+        interrupt_check(); // Check for interruptions
 
         correct_topology(manager);
 


### PR DESCRIPTION
Implements the ability to enable interruptions in wagyu code.

You are required to define `USE_WAGYU_INTERRUPT` when including the library and to call `interrupt_request` when you need the library to stop, usually when a trap has been triggered. Once the library notices the requests (the checks are mostly in the hottest loops) it will throw a `throw std::runtime_error` returning the control to the caller.

As I said in the ticket (https://github.com/mapbox/wagyu/issues/96) I'm not sure if this is interesting the the project, but it certainly would make our integration with upstream much easier (a simple copy and paste).