### PR TITLE
add  guard for execinfo.h

### DIFF
--- a/include/mapbox/geometry/wagyu/ring.hpp
+++ b/include/mapbox/geometry/wagyu/ring.hpp
@@ -11,7 +11,7 @@
 #include <sstream>
 #include <vector>
 
-#ifdef DEBUG
+#if defined(DEBUG) && __has_include(<execinfo.h>)
 #include <execinfo.h>
 #include <iostream>
 #include <sstream>

--- a/include/mapbox/geometry/wagyu/ring_util.hpp
+++ b/include/mapbox/geometry/wagyu/ring_util.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef DEBUG
+#if defined(DEBUG) && __has_include(<execinfo.h>)
 #include <iostream>
 // Example debug print for backtrace - only works on IOS
 #include <execinfo.h>


### PR DESCRIPTION
For windows wagyu wasn't working in debug due missing `execinfo.h`.